### PR TITLE
Add User search/introspect API

### DIFF
--- a/app/api/user-list.json
+++ b/app/api/user-list.json
@@ -1,0 +1,1808 @@
+[
+  {
+     "user_id": "9affb723-21d8-43c5-82ac-f525bf02444f",
+     "first_name": "Warren",
+     "last_name": "Mraz",
+     "email": "Tre.Ratke46@hotmail.com"
+  },
+  {
+     "user_id": "4e85bae4-6530-45ec-a7f3-d80895c3bc7f",
+     "first_name": "Kirstin",
+     "last_name": "Altenwerth",
+     "email": "Jeremy_Hagenes6@yahoo.com"
+  },
+  {
+     "user_id": "2250bec7-207f-4263-8880-d931802eb34a",
+     "first_name": "Ayana",
+     "last_name": "Vandervort",
+     "email": "Ewald_Koch66@yahoo.com"
+  },
+  {
+     "user_id": "04d822c3-700c-4512-a1ac-7d3e52a15062",
+     "first_name": "Jeremie",
+     "last_name": "Fritsch",
+     "email": "Erika.Hegmann@hotmail.com"
+  },
+  {
+     "user_id": "93098579-fe95-433a-8a50-553596608d65",
+     "first_name": "Valerie",
+     "last_name": "Ankunding",
+     "email": "Corbin93@hotmail.com"
+  },
+  {
+     "user_id": "a9355c1f-7d3a-4894-a8bc-9d5ad149e23d",
+     "first_name": "Johnny",
+     "last_name": "Wehner",
+     "email": "Sylvan.Gerhold23@hotmail.com"
+  },
+  {
+     "user_id": "3fbe6479-b9bd-4658-81d7-f07c2a73d33d",
+     "first_name": "Douglas",
+     "last_name": "Miller",
+     "email": "Flo_Schultz67@hotmail.com"
+  },
+  {
+     "user_id": "7c7f12ad-f6e3-4312-af65-2b98990137c1",
+     "first_name": "Andy",
+     "last_name": "Mueller",
+     "email": "Dale_Fay@gmail.com"
+  },
+  {
+     "user_id": "d698ca20-9c73-472d-b2fe-7ef040af3536",
+     "first_name": "Marlin",
+     "last_name": "Stoltenberg",
+     "email": "Marietta8@gmail.com"
+  },
+  {
+     "user_id": "c12195ed-bf30-4a67-ba73-e95cfe012f77",
+     "first_name": "Geraldine",
+     "last_name": "Kshlerin",
+     "email": "Sean22@yahoo.com"
+  },
+  {
+     "user_id": "437bd943-a76c-416b-853c-c6d776ba8416",
+     "first_name": "Kiera",
+     "last_name": "Feeney",
+     "email": "Adolph48@yahoo.com"
+  },
+  {
+     "user_id": "ad9e4368-11b3-4a29-8609-ee76ef75c59d",
+     "first_name": "Fred",
+     "last_name": "Hoppe",
+     "email": "Gerda88@gmail.com"
+  },
+  {
+     "user_id": "592400db-b6f3-49ab-ba0b-d86f9e313a79",
+     "first_name": "Stephany",
+     "last_name": "Collier",
+     "email": "Laverna.Lakin98@gmail.com"
+  },
+  {
+     "user_id": "f799d245-9b22-4254-b634-1f2329780367",
+     "first_name": "Jane",
+     "last_name": "Skiles",
+     "email": "Magdalen_West@gmail.com"
+  },
+  {
+     "user_id": "c515ec79-9134-4af2-9c33-c6f33e76a526",
+     "first_name": "John",
+     "last_name": "Schumm",
+     "email": "Emma.Gorczany65@yahoo.com"
+  },
+  {
+     "user_id": "9cf51129-176b-458e-98d1-7aa4f8a5f4eb",
+     "first_name": "Paul",
+     "last_name": "Raynor",
+     "email": "Shanon_Prohaska@gmail.com"
+  },
+  {
+     "user_id": "648b79bb-f20c-4508-aa43-69d1e507abcc",
+     "first_name": "Wilton",
+     "last_name": "Beahan",
+     "email": "Modesta9@hotmail.com"
+  },
+  {
+     "user_id": "c91f83d3-2bf8-428e-9c46-0db9104a947e",
+     "first_name": "Vickie",
+     "last_name": "Lubowitz",
+     "email": "Ethyl_Moen@gmail.com"
+  },
+  {
+     "user_id": "501706ca-1f67-407c-b2cc-870fbb688bc7",
+     "first_name": "Stacey",
+     "last_name": "Adams",
+     "email": "Marvin.Bartoletti@yahoo.com"
+  },
+  {
+     "user_id": "32c0a66a-73d2-482a-80c8-f59faca6c58a",
+     "first_name": "Jason",
+     "last_name": "Stiedemann",
+     "email": "Karen_Torp@hotmail.com"
+  },
+  {
+     "user_id": "4a6dc8a7-b10b-4404-8ed5-8b8a85d259dd",
+     "first_name": "Savannah",
+     "last_name": "Bayer",
+     "email": "Andreane.Becker48@yahoo.com"
+  },
+  {
+     "user_id": "0e68d295-38af-4bea-90b8-256f75367be8",
+     "first_name": "Dominic",
+     "last_name": "Cassin",
+     "email": "Graham.Konopelski16@yahoo.com"
+  },
+  {
+     "user_id": "6e362e74-4e89-4510-9c7b-63873e18c933",
+     "first_name": "Holly",
+     "last_name": "Schaefer",
+     "email": "Alexis.Stark@gmail.com"
+  },
+  {
+     "user_id": "2bc437ba-e31c-4bcd-a470-99b8faa21b9b",
+     "first_name": "Shaun",
+     "last_name": "Cruickshank",
+     "email": "Noemy67@yahoo.com"
+  },
+  {
+     "user_id": "438f9d33-64cb-4c08-afc2-52180e9a7ec6",
+     "first_name": "Sarah",
+     "last_name": "Mueller",
+     "email": "Garrison.Effertz@yahoo.com"
+  },
+  {
+     "user_id": "0cd8d401-ca66-44b4-bc65-c7532d21f01d",
+     "first_name": "Fred",
+     "last_name": "Yost",
+     "email": "Karina.Schneider93@yahoo.com"
+  },
+  {
+     "user_id": "ff79b5ac-1fe4-4779-b2b6-c4497e736f22",
+     "first_name": "Tim",
+     "last_name": "Bruen",
+     "email": "Lawson.Sanford@hotmail.com"
+  },
+  {
+     "user_id": "8ab40bf4-d409-4681-92cc-f81733674c2e",
+     "first_name": "Ralph",
+     "last_name": "Rippin",
+     "email": "Khalil.Quigley3@hotmail.com"
+  },
+  {
+     "user_id": "5f71ce95-5ee3-4c40-89d0-ffe5861ae912",
+     "first_name": "Zoey",
+     "last_name": "Roberts",
+     "email": "Tyler_Strosin89@hotmail.com"
+  },
+  {
+     "user_id": "d7364497-e972-4070-b530-7e7c4722a10f",
+     "first_name": "Kayleigh",
+     "last_name": "Orn",
+     "email": "Sonny.Bins15@yahoo.com"
+  },
+  {
+     "user_id": "028863ae-0c85-4d54-acb8-6fee49f358d2",
+     "first_name": "Elsie",
+     "last_name": "Boyle",
+     "email": "Lilly80@yahoo.com"
+  },
+  {
+     "user_id": "4a1f0c06-9aa0-45ab-831f-f8cff1f97e15",
+     "first_name": "Shane",
+     "last_name": "Torp",
+     "email": "Noel.Marks5@hotmail.com"
+  },
+  {
+     "user_id": "48ba8a7f-d190-4c9c-9caf-a1a413428a18",
+     "first_name": "Bonnie",
+     "last_name": "Rath",
+     "email": "Larry65@gmail.com"
+  },
+  {
+     "user_id": "5cf49d10-00be-4073-bad0-6929c3a4617a",
+     "first_name": "Johnnie",
+     "last_name": "Swaniawski",
+     "email": "Trinity53@gmail.com"
+  },
+  {
+     "user_id": "bef4e411-096a-4460-a206-64b058dab938",
+     "first_name": "Astrid",
+     "last_name": "Walsh",
+     "email": "Monte.Abshire@yahoo.com"
+  },
+  {
+     "user_id": "04f482b0-3875-4709-a952-6dfb79aaff2d",
+     "first_name": "Alanna",
+     "last_name": "Altenwerth",
+     "email": "Shawna_Willms36@hotmail.com"
+  },
+  {
+     "user_id": "15294588-dc6d-4b22-a140-6eb702bf102d",
+     "first_name": "Destin",
+     "last_name": "Quigley",
+     "email": "Dayne.Hoeger@yahoo.com"
+  },
+  {
+     "user_id": "6b63cebb-105d-47fc-907f-fdbafbf32fc5",
+     "first_name": "Anya",
+     "last_name": "Stiedemann",
+     "email": "Pablo_Ward@hotmail.com"
+  },
+  {
+     "user_id": "9be11a6e-51ff-4278-becb-64b3ce6ecc40",
+     "first_name": "Kira",
+     "last_name": "Gleichner",
+     "email": "Kory57@yahoo.com"
+  },
+  {
+     "user_id": "c329a285-25f4-42f6-8726-83827b9db397",
+     "first_name": "Grace",
+     "last_name": "Miller",
+     "email": "Irma.Cartwright@gmail.com"
+  },
+  {
+     "user_id": "7b9fbfbe-a243-4749-8b48-4c3dadbec222",
+     "first_name": "Christina",
+     "last_name": "Doe",
+     "email": "Gayle_Schaden70@yahoo.com"
+  },
+  {
+     "user_id": "a9c9914d-c836-42bd-a72f-1c9ac84bb425",
+     "first_name": "Bernie",
+     "last_name": "Buckridge",
+     "email": "Marcia42@hotmail.com"
+  },
+  {
+     "user_id": "9661d950-4c59-448c-8c8f-45830bd247c3",
+     "first_name": "Emily",
+     "last_name": "Kub",
+     "email": "Furman13@hotmail.com"
+  },
+  {
+     "user_id": "4c163968-0723-4a52-aa2f-ac390b646fb9",
+     "first_name": "Jane",
+     "last_name": "O'Connell",
+     "email": "Terrill_Rosenbaum85@hotmail.com"
+  },
+  {
+     "user_id": "8571944b-ad95-49ed-b859-7d386066ae64",
+     "first_name": "Hardy",
+     "last_name": "Walker",
+     "email": "Marlin.Weimann92@gmail.com"
+  },
+  {
+     "user_id": "772673d9-e42f-408e-aa3d-c05a9a7d4569",
+     "first_name": "Clara",
+     "last_name": "Kunde",
+     "email": "Tate_Towne93@hotmail.com"
+  },
+  {
+     "user_id": "c5662adc-c9ea-4ba7-abc1-18087cbd0ab5",
+     "first_name": "Nya",
+     "last_name": "Mayer",
+     "email": "Wade70@yahoo.com"
+  },
+  {
+     "user_id": "5e53b932-bc4b-4309-b571-c94ff17331b6",
+     "first_name": "Katarina",
+     "last_name": "Mueller",
+     "email": "Myah.Boehm33@gmail.com"
+  },
+  {
+     "user_id": "4b287a48-3ee0-4d8b-b71f-a4a7cb71cc73",
+     "first_name": "Leora",
+     "last_name": "Williamson",
+     "email": "Kaelyn_Reinger98@gmail.com"
+  },
+  {
+     "user_id": "33e15aa1-4a34-4035-847c-452e2d4a02d9",
+     "first_name": "Maximillia",
+     "last_name": "Labadie",
+     "email": "Haven_Yundt95@hotmail.com"
+  },
+  {
+     "user_id": "1b85785b-c4bb-4a25-971a-f41db30a6de9",
+     "first_name": "Shemar",
+     "last_name": "Huels",
+     "email": "Kasandra38@hotmail.com"
+  },
+  {
+     "user_id": "26a56673-44e8-47ca-9cbd-fe88cf0b687d",
+     "first_name": "Ronny",
+     "last_name": "Schuppe",
+     "email": "Van_Howe13@yahoo.com"
+  },
+  {
+     "user_id": "54b51e4e-5a53-42ad-a825-cacb7dd3c1fc",
+     "first_name": "Laron",
+     "last_name": "Tremblay",
+     "email": "Jimmie.Johns@hotmail.com"
+  },
+  {
+     "user_id": "cf067e9c-f631-4d8d-ae2a-77a0f47aa4ca",
+     "first_name": "Mose",
+     "last_name": "Jacobi",
+     "email": "Alexane_Jenkins97@gmail.com"
+  },
+  {
+     "user_id": "17928000-05e5-4ed8-a9f6-19f9dfeac557",
+     "first_name": "Tyson",
+     "last_name": "Johns",
+     "email": "Daron12@gmail.com"
+  },
+  {
+     "user_id": "ec466983-954e-4637-b209-9a7e842718e7",
+     "first_name": "Arianna",
+     "last_name": "Jacobson",
+     "email": "Hazel_Blick@yahoo.com"
+  },
+  {
+     "user_id": "7a75339d-d38c-4c46-be2f-1ff16163f2b7",
+     "first_name": "Kaitlyn",
+     "last_name": "Mraz",
+     "email": "Jaleel.Ondricka87@yahoo.com"
+  },
+  {
+     "user_id": "a27e48f5-b5ec-491d-ac4e-381be4dfc8c2",
+     "first_name": "Lily",
+     "last_name": "Goldner",
+     "email": "Jena_Wiza25@hotmail.com"
+  },
+  {
+     "user_id": "bc7b44d2-4862-4d83-acbe-413ad934f02b",
+     "first_name": "Dahlia",
+     "last_name": "Smitham",
+     "email": "Jeanne0@hotmail.com"
+  },
+  {
+     "user_id": "3fed1e9f-137f-4ddd-9090-942c949160c9",
+     "first_name": "Benton",
+     "last_name": "Nicolas",
+     "email": "Howard_Weber@gmail.com"
+  },
+  {
+     "user_id": "81310e6f-cdb6-4547-9d46-ca95b70176d4",
+     "first_name": "Jordon",
+     "last_name": "Leffler",
+     "email": "Alicia57@hotmail.com"
+  },
+  {
+     "user_id": "9a8c1e0c-b85e-4ac4-8f3d-a2976d0bb873",
+     "first_name": "Marquis",
+     "last_name": "Murazik",
+     "email": "Velda_Pouros@gmail.com"
+  },
+  {
+     "user_id": "17a92bed-11b0-488f-bdb0-06cac0591f58",
+     "first_name": "Dayton",
+     "last_name": "Rutherford",
+     "email": "Thaddeus52@gmail.com"
+  },
+  {
+     "user_id": "75a31205-b2b5-4432-b445-894ddcd5f2f7",
+     "first_name": "Torrance",
+     "last_name": "Lehner",
+     "email": "Floyd_Murray@hotmail.com"
+  },
+  {
+     "user_id": "6d8f816e-b2cc-4ba5-8540-d11c7d42b088",
+     "first_name": "Kitty",
+     "last_name": "Rutherford",
+     "email": "Geovany.Ferry5@gmail.com"
+  },
+  {
+     "user_id": "f4519fc7-6875-4414-a846-8b1f4f89cc8a",
+     "first_name": "Evelyn",
+     "last_name": "McCullough",
+     "email": "Tre.OConnell@gmail.com"
+  },
+  {
+     "user_id": "ab733236-d963-483c-a8ca-8733f21c1b3a",
+     "first_name": "Deron",
+     "last_name": "Auer",
+     "email": "Josiane59@gmail.com"
+  },
+  {
+     "user_id": "1209cda0-d500-4e72-afea-da91caf4b08d",
+     "first_name": "Hershel",
+     "last_name": "Crooks",
+     "email": "Brook.Gleason@hotmail.com"
+  },
+  {
+     "user_id": "1436589f-059f-4c31-a71e-c6fc97bb3591",
+     "first_name": "Callie",
+     "last_name": "Abernathy",
+     "email": "Lowell44@yahoo.com"
+  },
+  {
+     "user_id": "7db588cf-350e-45c5-a869-3ca6a281139d",
+     "first_name": "Markus",
+     "last_name": "Zulauf",
+     "email": "Garett_Blanda10@hotmail.com"
+  },
+  {
+     "user_id": "8c1ae486-a4bd-4507-9f0c-7d1d2ba5f194",
+     "first_name": "Maya",
+     "last_name": "Blick",
+     "email": "Emilia.Nikolaus@yahoo.com"
+  },
+  {
+     "user_id": "75e72a4c-60c7-49c8-8026-193919e6b13b",
+     "first_name": "Donnell",
+     "last_name": "Beatty",
+     "email": "Steve58@hotmail.com"
+  },
+  {
+     "user_id": "2baf10a4-6d61-4663-8cc0-080289c6305e",
+     "first_name": "Kenton",
+     "last_name": "Jaskolski",
+     "email": "Victoria81@gmail.com"
+  },
+  {
+     "user_id": "f6382a60-b2e9-44af-8a25-a2fd12aedb5a",
+     "first_name": "Jarrod",
+     "last_name": "Gerhold",
+     "email": "Zoila.Watsica48@yahoo.com"
+  },
+  {
+     "user_id": "a5aa5238-ed41-46bb-be23-b866b1dd0589",
+     "first_name": "Baylee",
+     "last_name": "Runolfsdottir",
+     "email": "Shyanne51@hotmail.com"
+  },
+  {
+     "user_id": "166d3983-fa71-4561-acc3-72dfbce3368f",
+     "first_name": "Marcelina",
+     "last_name": "O'Conner",
+     "email": "Emelia34@hotmail.com"
+  },
+  {
+     "user_id": "1e39395a-9a74-4d99-a120-eadf29d98f86",
+     "first_name": "Logan",
+     "last_name": "McGlynn",
+     "email": "Karl.Reichert83@yahoo.com"
+  },
+  {
+     "user_id": "351c525f-6cdb-4e76-9346-e71b5f068db6",
+     "first_name": "Savannah",
+     "last_name": "Gerhold",
+     "email": "Alycia_Bergstrom@hotmail.com"
+  },
+  {
+     "user_id": "c5e69efc-c408-4037-977a-361de62b50b0",
+     "first_name": "Kaya",
+     "last_name": "Luettgen",
+     "email": "Ulises_Greenholt89@gmail.com"
+  },
+  {
+     "user_id": "e7605f1d-c7dd-407b-bdc2-6f42604816dd",
+     "first_name": "Rodolfo",
+     "last_name": "Erdman",
+     "email": "Damion.Lubowitz@hotmail.com"
+  },
+  {
+     "user_id": "8f5e60d2-5fc4-4ff1-ba13-9986d6402d05",
+     "first_name": "Walton",
+     "last_name": "Flatley",
+     "email": "Asa26@hotmail.com"
+  },
+  {
+     "user_id": "5a9d0bce-38de-4efe-98a4-b592e9e5c40d",
+     "first_name": "Meghan",
+     "last_name": "Larson",
+     "email": "Cody.Emmerich93@hotmail.com"
+  },
+  {
+     "user_id": "c3812b48-cf7f-4a43-a5d1-1eaf24a62a46",
+     "first_name": "Kristopher",
+     "last_name": "Rowe",
+     "email": "Price54@gmail.com"
+  },
+  {
+     "user_id": "391bc176-10d3-440d-8578-5f8241ea065f",
+     "first_name": "Zack",
+     "last_name": "Rau",
+     "email": "Pearl.Weimann@gmail.com"
+  },
+  {
+     "user_id": "9a1f567c-5f8d-4a94-805e-6b94d8f39237",
+     "first_name": "Gregory",
+     "last_name": "Lynch",
+     "email": "Shea85@yahoo.com"
+  },
+  {
+     "user_id": "7ce4b1a4-dfc2-426c-bc7f-c495e47b666c",
+     "first_name": "Norma",
+     "last_name": "Leuschke",
+     "email": "Vivien_Wiegand92@yahoo.com"
+  },
+  {
+     "user_id": "72be53b9-f71e-435c-8263-e33c07353266",
+     "first_name": "Emmalee",
+     "last_name": "Greenfelder",
+     "email": "Bud80@gmail.com"
+  },
+  {
+     "user_id": "37fa143f-8af3-43d9-9828-8667e043a31a",
+     "first_name": "Lera",
+     "last_name": "Fadel",
+     "email": "Sarai_Kunde1@hotmail.com"
+  },
+  {
+     "user_id": "7e96905d-62d5-4ec9-81cf-d4d2007bc016",
+     "first_name": "Mable",
+     "last_name": "Morar",
+     "email": "Enrique.MacGyver@gmail.com"
+  },
+  {
+     "user_id": "b34477bb-03ef-4281-8c30-9c5d89ca2db6",
+     "first_name": "Tyreek",
+     "last_name": "Emard",
+     "email": "Angelina63@hotmail.com"
+  },
+  {
+     "user_id": "f118ca6c-1514-4a1a-9be7-56af0d0b190c",
+     "first_name": "Cassie",
+     "last_name": "Mertz",
+     "email": "Fritz_Daniel81@gmail.com"
+  },
+  {
+     "user_id": "a8d7283b-f0ce-4258-aa3b-346409437dc7",
+     "first_name": "Greg",
+     "last_name": "Gibson",
+     "email": "Andrew_Conroy62@yahoo.com"
+  },
+  {
+     "user_id": "a0fb3287-7cbc-44c9-a7e0-e7337c6cb824",
+     "first_name": "Tom",
+     "last_name": "Wiegand",
+     "email": "Grayson.Kemmer9@gmail.com"
+  },
+  {
+     "user_id": "0da5aef7-e869-4671-bbb5-8700d7538558",
+     "first_name": "Estevan",
+     "last_name": "Reinger",
+     "email": "Alta25@gmail.com"
+  },
+  {
+     "user_id": "7bcebc72-6b80-453f-8faf-edc4bfbeeb3f",
+     "first_name": "Gino",
+     "last_name": "Pfannerstill",
+     "email": "Anastasia_Gerhold@gmail.com"
+  },
+  {
+     "user_id": "cece8127-8d57-4f70-9ebb-c361231944f2",
+     "first_name": "Helen",
+     "last_name": "Gleason",
+     "email": "Belle23@hotmail.com"
+  },
+  {
+     "user_id": "e4347eba-95e4-4a1c-addd-a2d4f3617497",
+     "first_name": "Opal",
+     "last_name": "Strosin",
+     "email": "Lisette92@hotmail.com"
+  },
+  {
+     "user_id": "2414c830-3194-49c6-bf48-4bd6de43459b",
+     "first_name": "Justina",
+     "last_name": "Howell",
+     "email": "Jarrell.Howell96@gmail.com"
+  },
+  {
+     "user_id": "98710bf4-1ece-4a1b-a5ac-b7abc0194695",
+     "first_name": "Adella",
+     "last_name": "Marvin",
+     "email": "Callie.Berge@yahoo.com"
+  },
+  {
+     "user_id": "3c6e5830-00f4-4d83-b1a7-e068ab6e19b5",
+     "first_name": "Reagan",
+     "last_name": "VonRueden",
+     "email": "Casey16@hotmail.com"
+  },
+  {
+     "user_id": "601214ff-23a8-475d-a0f1-5fdab8669df3",
+     "first_name": "Freida",
+     "last_name": "Hyatt",
+     "email": "Otilia_Swift15@gmail.com"
+  },
+  {
+     "user_id": "b491a58b-0af6-4219-aa0e-bcb8a0db77ec",
+     "first_name": "Merl",
+     "last_name": "Reichert",
+     "email": "Aliya_Rice56@yahoo.com"
+  },
+  {
+     "user_id": "eac7913d-4d63-4694-9a9e-fa049bda4e57",
+     "first_name": "Reed",
+     "last_name": "Nienow",
+     "email": "Freda74@yahoo.com"
+  },
+  {
+     "user_id": "90cc3264-5c9d-470d-9179-4306f1b32a27",
+     "first_name": "Eladio",
+     "last_name": "Nicolas",
+     "email": "Tamia.Erdman76@gmail.com"
+  },
+  {
+     "user_id": "f6837047-e976-4ba6-85ca-38702cb7408d",
+     "first_name": "Guadalupe",
+     "last_name": "Borer",
+     "email": "Christa_McKenzie67@gmail.com"
+  },
+  {
+     "user_id": "80ac47fc-b824-4574-aff6-1b5ecbd7a191",
+     "first_name": "Rossie",
+     "last_name": "Gaylord",
+     "email": "Markus.Crist@gmail.com"
+  },
+  {
+     "user_id": "d57ef01a-9801-4dd5-b62c-c4c4924c5faf",
+     "first_name": "Khalil",
+     "last_name": "Spencer",
+     "email": "Isom_MacGyver@gmail.com"
+  },
+  {
+     "user_id": "351241e2-0318-4fb0-9e81-d4d050ee3dac",
+     "first_name": "Daisha",
+     "last_name": "Reilly",
+     "email": "Morris15@gmail.com"
+  },
+  {
+     "user_id": "18c64408-0e11-410f-bab6-b62461f7e328",
+     "first_name": "London",
+     "last_name": "Volkman",
+     "email": "Kelvin7@gmail.com"
+  },
+  {
+     "user_id": "34255ead-9ca9-42cd-ac93-a12bd3422c3f",
+     "first_name": "Kevin",
+     "last_name": "Daniel",
+     "email": "Melyssa51@hotmail.com"
+  },
+  {
+     "user_id": "8532fbb6-91ff-4806-bfaf-825d6908a834",
+     "first_name": "Camilla",
+     "last_name": "Koepp",
+     "email": "Jaeden_Larson23@hotmail.com"
+  },
+  {
+     "user_id": "bdcfe9c2-29c2-42cd-85c4-6866f02e48db",
+     "first_name": "Destin",
+     "last_name": "Douglas",
+     "email": "Rosalia_Rohan@gmail.com"
+  },
+  {
+     "user_id": "7770ee9d-a513-4365-8165-fd12c930d6b7",
+     "first_name": "Bessie",
+     "last_name": "Cruickshank",
+     "email": "Jarret_Leuschke96@yahoo.com"
+  },
+  {
+     "user_id": "ca145892-e1be-4d1b-ad1b-ac951f23ef91",
+     "first_name": "Genesis",
+     "last_name": "Leannon",
+     "email": "Mortimer.Hodkiewicz53@yahoo.com"
+  },
+  {
+     "user_id": "8217dfe3-7c05-487c-9785-2e44678e99e7",
+     "first_name": "Amparo",
+     "last_name": "Kuphal",
+     "email": "Santos.OKeefe@yahoo.com"
+  },
+  {
+     "user_id": "9f794ccf-588f-4406-ab52-0bea89600e3d",
+     "first_name": "Garry",
+     "last_name": "Denesik",
+     "email": "Mitchell_Bins@gmail.com"
+  },
+  {
+     "user_id": "a14f861c-afb6-41d5-9c19-d1e39a197a22",
+     "first_name": "Alva",
+     "last_name": "Upton",
+     "email": "Sandrine_Batz58@yahoo.com"
+  },
+  {
+     "user_id": "4a9f1676-6ef4-48e2-891e-f47901f1a719",
+     "first_name": "Hillary",
+     "last_name": "Reilly",
+     "email": "Lucile.Wisoky41@gmail.com"
+  },
+  {
+     "user_id": "fcd6c6b3-c2f0-402a-a593-6d029261403f",
+     "first_name": "Eloy",
+     "last_name": "Stehr",
+     "email": "Grady.Schamberger54@yahoo.com"
+  },
+  {
+     "user_id": "72d17014-269d-48e5-b93b-a4822a9543e0",
+     "first_name": "Jocelyn",
+     "last_name": "Buckridge",
+     "email": "Vaughn50@yahoo.com"
+  },
+  {
+     "user_id": "58470f7c-3c5a-4eb2-bdc7-d27e9a265ce3",
+     "first_name": "Jayne",
+     "last_name": "Hills",
+     "email": "Theresa73@yahoo.com"
+  },
+  {
+     "user_id": "5d1557ff-4978-435c-97f6-fd27e97cfd37",
+     "first_name": "Keyshawn",
+     "last_name": "Bergstrom",
+     "email": "Lurline41@yahoo.com"
+  },
+  {
+     "user_id": "32b7ba2f-470f-4d9e-832f-2504b742048c",
+     "first_name": "Ludwig",
+     "last_name": "Daugherty",
+     "email": "Elda.Haley47@yahoo.com"
+  },
+  {
+     "user_id": "0dae1308-77a9-484e-a200-e1ac53fbe74f",
+     "first_name": "Alycia",
+     "last_name": "Hudson",
+     "email": "Amelia_Flatley36@hotmail.com"
+  },
+  {
+     "user_id": "4b218e68-9261-4daa-a90d-347436978fee",
+     "first_name": "Giovanna",
+     "last_name": "Leannon",
+     "email": "Adam84@yahoo.com"
+  },
+  {
+     "user_id": "8925c8c6-a580-4bf7-990e-9b3fa90577b7",
+     "first_name": "Hadley",
+     "last_name": "Lindgren",
+     "email": "Lenna93@gmail.com"
+  },
+  {
+     "user_id": "a658de48-58b3-4d28-950a-f4726c2abd65",
+     "first_name": "Abner",
+     "last_name": "Spinka",
+     "email": "Celine_Borer@hotmail.com"
+  },
+  {
+     "user_id": "2ddd8907-963e-48b4-9ae9-02ebfcd9f0d6",
+     "first_name": "Sandra",
+     "last_name": "Runolfsson",
+     "email": "Sydni76@gmail.com"
+  },
+  {
+     "user_id": "9ccd68f4-3bb1-4846-ac6d-61ad787938c4",
+     "first_name": "Gonzalo",
+     "last_name": "Little",
+     "email": "Jordane_Kuphal@hotmail.com"
+  },
+  {
+     "user_id": "e1554ab3-75de-45a5-aab0-34c591cbc95a",
+     "first_name": "Walton",
+     "last_name": "Johnston",
+     "email": "Jaeden_Steuber77@hotmail.com"
+  },
+  {
+     "user_id": "0d42a0ad-d100-4e37-972d-d7e2b71ce975",
+     "first_name": "Murl",
+     "last_name": "Lueilwitz",
+     "email": "Shawna18@hotmail.com"
+  },
+  {
+     "user_id": "7bbead87-0e53-4d2b-ab01-f515482eb1ad",
+     "first_name": "Eusebio",
+     "last_name": "Raynor",
+     "email": "Bulah85@gmail.com"
+  },
+  {
+     "user_id": "865cd7b6-c3c2-4918-8d3f-f3899b58ffe3",
+     "first_name": "Murl",
+     "last_name": "Cremin",
+     "email": "Vallie_Larson3@gmail.com"
+  },
+  {
+     "user_id": "1f0ab03e-ff0a-427f-81e9-ebae41a0f455",
+     "first_name": "Makenzie",
+     "last_name": "O'Connell",
+     "email": "Arlie49@yahoo.com"
+  },
+  {
+     "user_id": "86a2177d-3f82-412d-ae0f-fd5af44cc785",
+     "first_name": "Melody",
+     "last_name": "Gaylord",
+     "email": "Albina89@yahoo.com"
+  },
+  {
+     "user_id": "174a24b9-ec43-4981-bfd7-483a4397125b",
+     "first_name": "Felton",
+     "last_name": "Runte",
+     "email": "Aurore89@hotmail.com"
+  },
+  {
+     "user_id": "f0253d9d-a935-4159-84cc-9887ccf19770",
+     "first_name": "Rickey",
+     "last_name": "Bartell",
+     "email": "Marcus.Ritchie75@yahoo.com"
+  },
+  {
+     "user_id": "df401f4d-0b86-484c-8f1f-b8697d852040",
+     "first_name": "Georgette",
+     "last_name": "Treutel",
+     "email": "Jamir_Ratke16@hotmail.com"
+  },
+  {
+     "user_id": "a7fd83c4-083f-445e-a6c0-9f20b6bdd229",
+     "first_name": "Kris",
+     "last_name": "Koss",
+     "email": "Fanny.OHara@gmail.com"
+  },
+  {
+     "user_id": "2e3c9bdd-a5ee-44d2-bfc6-e057e42d4088",
+     "first_name": "Ladarius",
+     "last_name": "Beatty",
+     "email": "Luisa.Thompson87@yahoo.com"
+  },
+  {
+     "user_id": "06b25a5f-e572-4059-a2ea-8176eed73f8a",
+     "first_name": "Axel",
+     "last_name": "Greenfelder",
+     "email": "Sammie.Bahringer20@hotmail.com"
+  },
+  {
+     "user_id": "a92f550c-c2b3-4e20-8882-18f6300e23f7",
+     "first_name": "Itzel",
+     "last_name": "Wilkinson",
+     "email": "Kaylee.Kris13@yahoo.com"
+  },
+  {
+     "user_id": "297d3185-f704-4c51-8646-6eed41c06a8d",
+     "first_name": "Cortney",
+     "last_name": "Rowe",
+     "email": "Eliza30@yahoo.com"
+  },
+  {
+     "user_id": "340c4e2c-0b4b-4df7-b234-53617164225a",
+     "first_name": "Jeromy",
+     "last_name": "Rippin",
+     "email": "Lawson_Shields66@gmail.com"
+  },
+  {
+     "user_id": "35a64bdb-d4dd-44dc-96c8-4b106349b15b",
+     "first_name": "Margarett",
+     "last_name": "Pagac",
+     "email": "Micheal70@yahoo.com"
+  },
+  {
+     "user_id": "2727d4e1-1cab-4c23-9e2c-53931950bdcb",
+     "first_name": "Joaquin",
+     "last_name": "Davis",
+     "email": "Meghan17@yahoo.com"
+  },
+  {
+     "user_id": "54c16285-1dae-4abc-88b6-82d812a94653",
+     "first_name": "Jess",
+     "last_name": "Corkery",
+     "email": "Jules91@hotmail.com"
+  },
+  {
+     "user_id": "7075d9a6-c6a4-4c4e-9a5b-e0e00e4c90b6",
+     "first_name": "Gregorio",
+     "last_name": "Huels",
+     "email": "Mckenna61@yahoo.com"
+  },
+  {
+     "user_id": "a3c7f52d-e7be-4fad-aec7-4afa4a80a9b9",
+     "first_name": "Mazie",
+     "last_name": "Moen",
+     "email": "Coleman_Mueller@yahoo.com"
+  },
+  {
+     "user_id": "c3449f7a-9f0a-4128-8067-f11d5163cce1",
+     "first_name": "Yazmin",
+     "last_name": "Huels",
+     "email": "Magnolia_Armstrong@yahoo.com"
+  },
+  {
+     "user_id": "1e5e0af4-1d92-4f1f-aec0-804c32f722a5",
+     "first_name": "Gideon",
+     "last_name": "Heathcote",
+     "email": "Alessandro4@gmail.com"
+  },
+  {
+     "user_id": "f6693821-51c7-4ef4-8148-07db07ff6d35",
+     "first_name": "Aiyana",
+     "last_name": "Marquardt",
+     "email": "Axel_Turcotte33@yahoo.com"
+  },
+  {
+     "user_id": "be922588-4b39-4731-93cc-64be89bd3d4a",
+     "first_name": "Alfred",
+     "last_name": "Schamberger",
+     "email": "Myriam47@hotmail.com"
+  },
+  {
+     "user_id": "0733b8f5-c17c-4a6d-a740-e97000956eec",
+     "first_name": "Andy",
+     "last_name": "Kuphal",
+     "email": "Blair81@hotmail.com"
+  },
+  {
+     "user_id": "8244b7b0-ba98-4ab1-9b48-7c56447bf0fc",
+     "first_name": "Fidel",
+     "last_name": "Schamberger",
+     "email": "Odie30@hotmail.com"
+  },
+  {
+     "user_id": "fb7b6090-ab77-4d34-ab7b-18bc0cb8770d",
+     "first_name": "Emelie",
+     "last_name": "Smith",
+     "email": "Lea91@gmail.com"
+  },
+  {
+     "user_id": "7c5e9e64-1aab-4f78-bf5a-a07f5037b60c",
+     "first_name": "Brendon",
+     "last_name": "Nader",
+     "email": "Brando31@yahoo.com"
+  },
+  {
+     "user_id": "dc0ab007-4b12-4590-b7eb-075613a4bed3",
+     "first_name": "Emmie",
+     "last_name": "Little",
+     "email": "Arlie.Emard56@gmail.com"
+  },
+  {
+     "user_id": "40dda628-8b2a-4c1f-b52c-6e2f3425ccd5",
+     "first_name": "Shemar",
+     "last_name": "Schultz",
+     "email": "Linwood_Okuneva44@gmail.com"
+  },
+  {
+     "user_id": "ca4e2ead-d773-4de4-944f-bd7c006a49f1",
+     "first_name": "Chadrick",
+     "last_name": "White",
+     "email": "Lori_Gulgowski@hotmail.com"
+  },
+  {
+     "user_id": "72e34540-bcba-4f1b-aa1b-6cd19194be05",
+     "first_name": "Casandra",
+     "last_name": "Skiles",
+     "email": "Misty.OKon2@hotmail.com"
+  },
+  {
+     "user_id": "a7bafaad-3852-433a-bd72-da7ec73fe47f",
+     "first_name": "Gia",
+     "last_name": "McKenzie",
+     "email": "Alfonso99@gmail.com"
+  },
+  {
+     "user_id": "490a2725-7894-4d07-9015-f1ae6b334323",
+     "first_name": "Kavon",
+     "last_name": "Grady",
+     "email": "Arlie29@gmail.com"
+  },
+  {
+     "user_id": "a6c3abcb-178b-4fec-845c-bb0f3a2dceeb",
+     "first_name": "Margot",
+     "last_name": "McKenzie",
+     "email": "Ara.Jast@yahoo.com"
+  },
+  {
+     "user_id": "8120ba42-a30b-4b34-8375-4e57688a8cd1",
+     "first_name": "Talon",
+     "last_name": "Blick",
+     "email": "Silas.Jaskolski@hotmail.com"
+  },
+  {
+     "user_id": "fd536195-6de0-4f6f-858a-fbef8b57410d",
+     "first_name": "Kiera",
+     "last_name": "Grady",
+     "email": "Savanah64@gmail.com"
+  },
+  {
+     "user_id": "69f01b03-fd29-45cf-8805-bbd17fbf59c6",
+     "first_name": "Maci",
+     "last_name": "Stanton",
+     "email": "Marianne15@yahoo.com"
+  },
+  {
+     "user_id": "f95a8c0e-4028-468e-996d-1a417f2b1f07",
+     "first_name": "Delilah",
+     "last_name": "Howe",
+     "email": "Julien_Bogisich@yahoo.com"
+  },
+  {
+     "user_id": "1e2e5f1e-ba00-4a5f-ab7c-ba66eec7ccae",
+     "first_name": "Nelle",
+     "last_name": "Smith",
+     "email": "Reva.Kilback89@gmail.com"
+  },
+  {
+     "user_id": "bbdb7c13-d8c3-4570-8d01-23f2c9a20f8a",
+     "first_name": "Jacinto",
+     "last_name": "Mayer",
+     "email": "Camylle.Dickens@gmail.com"
+  },
+  {
+     "user_id": "dc0cdf91-f70e-42b2-8809-04523d195e54",
+     "first_name": "Clemmie",
+     "last_name": "Yost",
+     "email": "Ernesto_Johnson@hotmail.com"
+  },
+  {
+     "user_id": "65424244-cc9c-4da2-a2d7-2dc796ccfdec",
+     "first_name": "Wilfrid",
+     "last_name": "Hermann",
+     "email": "Skylar.Bernier@yahoo.com"
+  },
+  {
+     "user_id": "9aab9001-0aa5-4a8f-8859-689aaf4abcb3",
+     "first_name": "Roberto",
+     "last_name": "Kessler",
+     "email": "Ivory79@gmail.com"
+  },
+  {
+     "user_id": "639597e1-e907-48b6-9bf2-3f81554a1bee",
+     "first_name": "Lizzie",
+     "last_name": "Grimes",
+     "email": "Bennett63@hotmail.com"
+  },
+  {
+     "user_id": "e0b424f4-87b7-4cd0-96dd-0d9d1f5905ab",
+     "first_name": "Minerva",
+     "last_name": "Hoppe",
+     "email": "Cyril_Ondricka3@yahoo.com"
+  },
+  {
+     "user_id": "81a70834-7183-4738-bcb4-e11b61287882",
+     "first_name": "Mattie",
+     "last_name": "Monahan",
+     "email": "Lorenz2@hotmail.com"
+  },
+  {
+     "user_id": "af788f51-622a-47bd-8018-d5af6b75b41d",
+     "first_name": "Sigurd",
+     "last_name": "Rohan",
+     "email": "Jordon46@gmail.com"
+  },
+  {
+     "user_id": "3942f262-2377-459c-be5f-84bc855a97d8",
+     "first_name": "Stacey",
+     "last_name": "Veum",
+     "email": "Toney1@gmail.com"
+  },
+  {
+     "user_id": "278bbf80-84a2-45e0-9f17-e2e8c4ad1d2a",
+     "first_name": "Dino",
+     "last_name": "Donnelly",
+     "email": "Madilyn.Schowalter15@gmail.com"
+  },
+  {
+     "user_id": "a4b8dd9f-bf6b-4cfd-9400-d21d4759d48a",
+     "first_name": "Morton",
+     "last_name": "Rosenbaum",
+     "email": "Margarette_Weissnat@gmail.com"
+  },
+  {
+     "user_id": "8f8d68af-a250-4d5c-b1c2-7ae46acc20db",
+     "first_name": "Davon",
+     "last_name": "Pacocha",
+     "email": "Cory_Ankunding4@hotmail.com"
+  },
+  {
+     "user_id": "a150bd7f-6fbc-457b-9cbf-ee808b976132",
+     "first_name": "Shanna",
+     "last_name": "Tromp",
+     "email": "Arvel73@yahoo.com"
+  },
+  {
+     "user_id": "7406290e-d615-4ec0-be0b-9f0e072d8c15",
+     "first_name": "Abdiel",
+     "last_name": "Kohler",
+     "email": "Elian_Stroman@gmail.com"
+  },
+  {
+     "user_id": "5e7cb3d1-deaf-4cb0-a55e-60fab4d91f5f",
+     "first_name": "Edna",
+     "last_name": "Jaskolski",
+     "email": "Jaida_Hegmann63@hotmail.com"
+  },
+  {
+     "user_id": "b2d14d1e-ea3b-4827-976c-b9800b129d23",
+     "first_name": "Antonette",
+     "last_name": "Veum",
+     "email": "Amalia.MacGyver@yahoo.com"
+  },
+  {
+     "user_id": "541d921d-1c7f-4f97-9d12-477b3b5c7980",
+     "first_name": "Kyla",
+     "last_name": "Rau",
+     "email": "Micaela23@gmail.com"
+  },
+  {
+     "user_id": "00404f9a-87f9-425a-80a6-58e839e875ca",
+     "first_name": "Kenny",
+     "last_name": "Macejkovic",
+     "email": "Frankie10@hotmail.com"
+  },
+  {
+     "user_id": "ecfe0456-8e18-4c93-ac54-1e562036b717",
+     "first_name": "Reymundo",
+     "last_name": "Lang",
+     "email": "Rod_Windler@gmail.com"
+  },
+  {
+     "user_id": "3e5183b9-41cc-468a-b060-a178e0019ec4",
+     "first_name": "Rosalind",
+     "last_name": "Lehner",
+     "email": "Akeem94@yahoo.com"
+  },
+  {
+     "user_id": "7cbd642e-5e91-46d9-9d39-6e5d720c49c1",
+     "first_name": "Howard",
+     "last_name": "Hartmann",
+     "email": "Veronica96@yahoo.com"
+  },
+  {
+     "user_id": "a6dbe34e-e7c5-466b-a30c-f575c2e62c3a",
+     "first_name": "Thurman",
+     "last_name": "Jast",
+     "email": "Mckayla_Doyle59@gmail.com"
+  },
+  {
+     "user_id": "f0e47e08-365b-4d5f-bc35-2baea56e7015",
+     "first_name": "Litzy",
+     "last_name": "Greenfelder",
+     "email": "Marietta70@hotmail.com"
+  },
+  {
+     "user_id": "3782a673-dd87-4961-a29d-a0331069f346",
+     "first_name": "Drew",
+     "last_name": "Swaniawski",
+     "email": "Karley_Batz21@hotmail.com"
+  },
+  {
+     "user_id": "9b3fecdb-93a2-4078-8841-c5b0b2f9899d",
+     "first_name": "Frida",
+     "last_name": "Kling",
+     "email": "Elton_Douglas@hotmail.com"
+  },
+  {
+     "user_id": "d9a6a68a-13f8-40de-a409-1be90a19a873",
+     "first_name": "Anais",
+     "last_name": "Schulist",
+     "email": "Agustina73@yahoo.com"
+  },
+  {
+     "user_id": "bb57a9e2-2fd8-4512-9a8c-c9f2b3a3b4ef",
+     "first_name": "Gerhard",
+     "last_name": "Harvey",
+     "email": "Oren_Price@hotmail.com"
+  },
+  {
+     "user_id": "4dd0bfc9-12a5-4fd3-892c-4eb6cd860377",
+     "first_name": "Abigayle",
+     "last_name": "Bechtelar",
+     "email": "Blanca28@gmail.com"
+  },
+  {
+     "user_id": "dd94851a-60e7-4571-9f25-7c07363650ff",
+     "first_name": "Jacynthe",
+     "last_name": "Dooley",
+     "email": "Laurianne7@hotmail.com"
+  },
+  {
+     "user_id": "9f221376-74f7-44a2-9ffa-78abcca1a04e",
+     "first_name": "Kylie",
+     "last_name": "Graham",
+     "email": "Kay69@yahoo.com"
+  },
+  {
+     "user_id": "da8b8d68-c297-4f2f-aa08-7116d03d97cc",
+     "first_name": "Wade",
+     "last_name": "Kerluke",
+     "email": "Norberto17@hotmail.com"
+  },
+  {
+     "user_id": "62b006b0-3cdc-405e-ba39-f7ab19b34735",
+     "first_name": "Daisha",
+     "last_name": "Spencer",
+     "email": "Elinore39@gmail.com"
+  },
+  {
+     "user_id": "1e063174-2b8f-4216-af15-f6a437e0602e",
+     "first_name": "Autumn",
+     "last_name": "Zieme",
+     "email": "Rylee26@hotmail.com"
+  },
+  {
+     "user_id": "d50b822c-fba9-4c3b-b764-d467d387967b",
+     "first_name": "Colt",
+     "last_name": "Zieme",
+     "email": "Lucienne75@yahoo.com"
+  },
+  {
+     "user_id": "39be00aa-4e37-4914-a8c6-7b0e725b1103",
+     "first_name": "Joey",
+     "last_name": "Bayer",
+     "email": "Genoveva58@gmail.com"
+  },
+  {
+     "user_id": "5b903c6c-9899-407b-b093-7ae511a8ea2d",
+     "first_name": "Rossie",
+     "last_name": "Cormier",
+     "email": "Selena52@gmail.com"
+  },
+  {
+     "user_id": "16733947-d872-41bf-aba5-e36ea8cb55e3",
+     "first_name": "Ken",
+     "last_name": "Ebert",
+     "email": "Giovanna97@hotmail.com"
+  },
+  {
+     "user_id": "651dc47d-e827-4073-9dba-26c5fb830e3c",
+     "first_name": "Lacy",
+     "last_name": "Swaniawski",
+     "email": "Elna_Feil@hotmail.com"
+  },
+  {
+     "user_id": "edb9c875-6b85-471f-b535-7fac6d96e49b",
+     "first_name": "Agustin",
+     "last_name": "McClure",
+     "email": "Holden.Jaskolski18@hotmail.com"
+  },
+  {
+     "user_id": "1c407e31-fba1-459a-8c09-ec8c6a974b1c",
+     "first_name": "Carson",
+     "last_name": "Klein",
+     "email": "Sally_Stamm95@yahoo.com"
+  },
+  {
+     "user_id": "463c0f43-9c5f-4f83-97d9-a1cd92d22b9e",
+     "first_name": "Karson",
+     "last_name": "Champlin",
+     "email": "Fatima88@yahoo.com"
+  },
+  {
+     "user_id": "2a224d50-8a40-4663-8e6b-fc67c591b9a0",
+     "first_name": "Maida",
+     "last_name": "Morissette",
+     "email": "Nat_Kilback34@hotmail.com"
+  },
+  {
+     "user_id": "f2f23429-20a9-4ac6-a76f-43c7d3f8edae",
+     "first_name": "General",
+     "last_name": "Bailey",
+     "email": "Kane73@hotmail.com"
+  },
+  {
+     "user_id": "140eeba7-f208-4606-8159-13a9fd4ee18c",
+     "first_name": "Ryley",
+     "last_name": "Bartell",
+     "email": "Adolph47@yahoo.com"
+  },
+  {
+     "user_id": "bf3f84ce-3f43-400a-8532-1a6f86e4ea90",
+     "first_name": "Vernie",
+     "last_name": "Rodriguez",
+     "email": "Michaela_Stehr@hotmail.com"
+  },
+  {
+     "user_id": "0c8d2df8-f4ea-4f4c-b2f0-5d07151743ec",
+     "first_name": "Freida",
+     "last_name": "West",
+     "email": "Annamae_Rohan25@yahoo.com"
+  },
+  {
+     "user_id": "ebeb4b82-f070-491a-a01b-432c5fd180ed",
+     "first_name": "Mack",
+     "last_name": "Pfeffer",
+     "email": "Lolita11@gmail.com"
+  },
+  {
+     "user_id": "8dc317b7-103e-48aa-9baf-f1b5bfb7196e",
+     "first_name": "Brooklyn",
+     "last_name": "Rohan",
+     "email": "Savanna_Reynolds@gmail.com"
+  },
+  {
+     "user_id": "069a493d-0e95-4d27-9c5f-e1f578209a1f",
+     "first_name": "Eveline",
+     "last_name": "Veum",
+     "email": "Soledad88@hotmail.com"
+  },
+  {
+     "user_id": "50db97f8-8539-451d-93ba-da546693b171",
+     "first_name": "Alejandrin",
+     "last_name": "Schuster",
+     "email": "Eveline_McCullough@hotmail.com"
+  },
+  {
+     "user_id": "91ebf19b-0aa0-4054-a6c4-7f6242f577d7",
+     "first_name": "Yvette",
+     "last_name": "Green",
+     "email": "Demetrius72@gmail.com"
+  },
+  {
+     "user_id": "e0b2ef94-a079-4dda-a2b5-a781d14757db",
+     "first_name": "Arnulfo",
+     "last_name": "O'Connell",
+     "email": "Hallie_Kuhn13@gmail.com"
+  },
+  {
+     "user_id": "a65f24be-604e-41d3-89cf-b6fede2e5328",
+     "first_name": "Amara",
+     "last_name": "Welch",
+     "email": "Adrain79@yahoo.com"
+  },
+  {
+     "user_id": "47e00469-e67f-4e2e-9017-ccc92d8f33ff",
+     "first_name": "Heber",
+     "last_name": "Schumm",
+     "email": "Martine_Hilpert61@gmail.com"
+  },
+  {
+     "user_id": "a785db04-401f-494b-aa32-40daa33f44b0",
+     "first_name": "Zion",
+     "last_name": "Bergstrom",
+     "email": "Claud_Lebsack2@hotmail.com"
+  },
+  {
+     "user_id": "547c82e0-a9ca-475f-8a3c-bd609075829a",
+     "first_name": "Henriette",
+     "last_name": "DuBuque",
+     "email": "Ubaldo.Walsh94@yahoo.com"
+  },
+  {
+     "user_id": "e42273fa-7401-4574-a87a-83333210fa81",
+     "first_name": "Piper",
+     "last_name": "Runte",
+     "email": "Cole_Corwin79@gmail.com"
+  },
+  {
+     "user_id": "dbb4ef9d-b48a-401c-8958-e64d149543c6",
+     "first_name": "Eloise",
+     "last_name": "Bartoletti",
+     "email": "Margie38@gmail.com"
+  },
+  {
+     "user_id": "7dc5a807-66e6-44cd-bb01-b001c8acc527",
+     "first_name": "Levi",
+     "last_name": "Halvorson",
+     "email": "Ned.McKenzie44@hotmail.com"
+  },
+  {
+     "user_id": "dadb1609-2e8b-48cf-857c-1aad448ab09a",
+     "first_name": "Natalia",
+     "last_name": "Hills",
+     "email": "Sharon_Terry34@hotmail.com"
+  },
+  {
+     "user_id": "0857033c-a56d-44dd-8092-d84cf4e8a88a",
+     "first_name": "Cletus",
+     "last_name": "Ondricka",
+     "email": "Maxime_Schuppe32@yahoo.com"
+  },
+  {
+     "user_id": "c1c4c164-51e4-4adb-a98c-ff6a5b766b51",
+     "first_name": "Neoma",
+     "last_name": "West",
+     "email": "Ellsworth6@yahoo.com"
+  },
+  {
+     "user_id": "bb771bac-113d-4c81-8a40-1dc48cf544cb",
+     "first_name": "Jamar",
+     "last_name": "Hintz",
+     "email": "Kade.McLaughlin96@hotmail.com"
+  },
+  {
+     "user_id": "cb955193-715c-4ca3-95de-06f1b26d17e0",
+     "first_name": "Elisha",
+     "last_name": "Feil",
+     "email": "Erna_Marquardt@gmail.com"
+  },
+  {
+     "user_id": "5e9ecf1d-63c4-4baa-9d89-d84c8839c8f9",
+     "first_name": "Rosalyn",
+     "last_name": "Connelly",
+     "email": "Kitty35@hotmail.com"
+  },
+  {
+     "user_id": "ac74e83c-f48c-4c83-af31-d1d0e403cccc",
+     "first_name": "Wava",
+     "last_name": "Shanahan",
+     "email": "Reyes31@yahoo.com"
+  },
+  {
+     "user_id": "10e975ee-e183-45f7-88e7-a1fbac223818",
+     "first_name": "Osvaldo",
+     "last_name": "Sauer",
+     "email": "Evan.Raynor@gmail.com"
+  },
+  {
+     "user_id": "28a3ff8b-ad1c-468d-9d6c-20399128824a",
+     "first_name": "Monserrat",
+     "last_name": "Ziemann",
+     "email": "Nils_Jacobs71@yahoo.com"
+  },
+  {
+     "user_id": "71ed9792-c081-4323-b2b0-3cdbc09aaf71",
+     "first_name": "Dolly",
+     "last_name": "Lehner",
+     "email": "Augustine25@gmail.com"
+  },
+  {
+     "user_id": "c736e1cb-37fd-4d92-99e1-241898807f0e",
+     "first_name": "Sheila",
+     "last_name": "Runte",
+     "email": "Deangelo_Rutherford@yahoo.com"
+  },
+  {
+     "user_id": "e528e0c3-c748-41c8-af00-51f510503c94",
+     "first_name": "Nestor",
+     "last_name": "Hintz",
+     "email": "Elva73@hotmail.com"
+  },
+  {
+     "user_id": "383b1393-68b5-4796-8be5-6af9d4f2d773",
+     "first_name": "Salma",
+     "last_name": "VonRueden",
+     "email": "Keyon.Wuckert99@gmail.com"
+  },
+  {
+     "user_id": "18321b07-3693-49a0-a13e-4bc89a6b38ff",
+     "first_name": "Janis",
+     "last_name": "Gibson",
+     "email": "Chaz97@hotmail.com"
+  },
+  {
+     "user_id": "e77bf181-441f-47c0-a79e-1e88a33115c7",
+     "first_name": "Maximus",
+     "last_name": "Lynch",
+     "email": "Gonzalo.Nienow@gmail.com"
+  },
+  {
+     "user_id": "6356e98c-1bcd-4d85-841a-e82b23e1e968",
+     "first_name": "Roel",
+     "last_name": "Satterfield",
+     "email": "Deshawn.Grant72@gmail.com"
+  },
+  {
+     "user_id": "df2b3b44-c917-4a51-8203-8325813b9fc5",
+     "first_name": "Jada",
+     "last_name": "Rowe",
+     "email": "Queenie.Mueller@hotmail.com"
+  },
+  {
+     "user_id": "2fe5bb06-b98a-4a5e-800c-a6d888e21063",
+     "first_name": "Frederique",
+     "last_name": "Schmidt",
+     "email": "Macy6@hotmail.com"
+  },
+  {
+     "user_id": "37455346-aa33-430a-bfff-1e7489041aa0",
+     "first_name": "Levi",
+     "last_name": "Wiza",
+     "email": "Ollie43@yahoo.com"
+  },
+  {
+     "user_id": "13779ab2-6544-46b4-8e54-f673fff8b807",
+     "first_name": "Pierre",
+     "last_name": "Mertz",
+     "email": "Noel_Kirlin@hotmail.com"
+  },
+  {
+     "user_id": "5128e955-1d36-4936-88e4-4529347a8966",
+     "first_name": "Elnora",
+     "last_name": "Murazik",
+     "email": "Javier_Boyer@yahoo.com"
+  },
+  {
+     "user_id": "ee6b599c-f851-4141-8586-2b923b20aaa0",
+     "first_name": "Treva",
+     "last_name": "Mayert",
+     "email": "Kirk_Bogisich@yahoo.com"
+  },
+  {
+     "user_id": "d07e63ae-2e0d-48bf-bab8-00385a12c37c",
+     "first_name": "Alverta",
+     "last_name": "Kohler",
+     "email": "Sheridan_Dare@yahoo.com"
+  },
+  {
+     "user_id": "38ac1a92-ac69-4fe9-8e6b-40488928fc96",
+     "first_name": "Dejah",
+     "last_name": "Kessler",
+     "email": "Ayana54@hotmail.com"
+  },
+  {
+     "user_id": "769c0688-18e5-48fa-a580-c1da4d9bf1a0",
+     "first_name": "Adolf",
+     "last_name": "Altenwerth",
+     "email": "Rollin_Waters16@gmail.com"
+  },
+  {
+     "user_id": "7f4dd96b-01f1-4245-8ede-b718d168b060",
+     "first_name": "Schuyler",
+     "last_name": "Hermann",
+     "email": "Tobin_Greenfelder@gmail.com"
+  },
+  {
+     "user_id": "e9114c1c-4a4a-4846-8bac-e5b9ebcbe69d",
+     "first_name": "Lavonne",
+     "last_name": "Stoltenberg",
+     "email": "Imelda.Lebsack92@gmail.com"
+  },
+  {
+     "user_id": "7f03cb7e-d5fb-40f3-aad2-5407fff5d390",
+     "first_name": "Cullen",
+     "last_name": "Collins",
+     "email": "Harold55@gmail.com"
+  },
+  {
+     "user_id": "53244893-b612-492c-a459-59ea683184e4",
+     "first_name": "Coleman",
+     "last_name": "Mraz",
+     "email": "Liliana_OConnell30@yahoo.com"
+  },
+  {
+     "user_id": "897e47ec-4bde-4db2-8bf4-e2165ed37e9b",
+     "first_name": "Leilani",
+     "last_name": "Rowe",
+     "email": "Chris97@hotmail.com"
+  },
+  {
+     "user_id": "1cc53db7-05fa-41a1-b8e8-6a6df4f548ab",
+     "first_name": "Santina",
+     "last_name": "Kris",
+     "email": "Deja93@hotmail.com"
+  },
+  {
+     "user_id": "8e354832-56d5-499d-b274-3371d884d351",
+     "first_name": "Pearlie",
+     "last_name": "Bednar",
+     "email": "Ines64@gmail.com"
+  },
+  {
+     "user_id": "f808a09a-f22d-4eaa-a5b3-5b47b6fb3827",
+     "first_name": "Kaylie",
+     "last_name": "Stark",
+     "email": "Juliet.Bahringer@hotmail.com"
+  },
+  {
+     "user_id": "367c150c-c1d9-4c83-ad01-7d35624f1747",
+     "first_name": "Carleton",
+     "last_name": "Walsh",
+     "email": "Chandler.Corwin88@gmail.com"
+  },
+  {
+     "user_id": "211b04c6-6fd5-4961-b325-8fe27fd07905",
+     "first_name": "Casandra",
+     "last_name": "Will",
+     "email": "Tomasa.Denesik58@gmail.com"
+  },
+  {
+     "user_id": "442ee655-25a7-4144-9499-b7ce10366f14",
+     "first_name": "Sophie",
+     "last_name": "Fay",
+     "email": "Eliezer_Abshire8@hotmail.com"
+  },
+  {
+     "user_id": "e0cc4cdc-d01b-497a-b991-44f7b0b7dd11",
+     "first_name": "Erica",
+     "last_name": "Koepp",
+     "email": "Uriah15@gmail.com"
+  },
+  {
+     "user_id": "4f658ce4-fc34-479a-91bb-c890e6292607",
+     "first_name": "Linnea",
+     "last_name": "Legros",
+     "email": "Graciela44@yahoo.com"
+  },
+  {
+     "user_id": "b1dd9548-9a3a-4d12-9f16-d60dad2a6c2c",
+     "first_name": "Carol",
+     "last_name": "Block",
+     "email": "Ole23@hotmail.com"
+  },
+  {
+     "user_id": "ebc49112-5d3f-48ac-8742-23b26bb9de63",
+     "first_name": "Ettie",
+     "last_name": "Russel",
+     "email": "Justen_Hintz@yahoo.com"
+  },
+  {
+     "user_id": "b508c0ed-4a58-4e00-9507-c12972b8db62",
+     "first_name": "Vida",
+     "last_name": "Gutmann",
+     "email": "Lynn_Pouros60@yahoo.com"
+  },
+  {
+     "user_id": "764525d5-7b64-4f44-aaed-1f3d7d39ec24",
+     "first_name": "Eliezer",
+     "last_name": "Ullrich",
+     "email": "Treva_Schuster@gmail.com"
+  },
+  {
+     "user_id": "6ede030b-0153-4233-87c3-e8be86ca5171",
+     "first_name": "Felipa",
+     "last_name": "Rolfson",
+     "email": "Celia_Will@gmail.com"
+  },
+  {
+     "user_id": "1df24a8d-3713-444f-9279-34fca8f75450",
+     "first_name": "Mario",
+     "last_name": "Treutel",
+     "email": "Darryl_Murray@hotmail.com"
+  },
+  {
+     "user_id": "7dd374f6-9630-4baa-a45f-8166c4fa1842",
+     "first_name": "Joelle",
+     "last_name": "Lowe",
+     "email": "Iliana40@hotmail.com"
+  },
+  {
+     "user_id": "6cd2d066-4204-4f6c-a29d-5ca460db3070",
+     "first_name": "Beverly",
+     "last_name": "Parisian",
+     "email": "Ruthie.Blanda89@yahoo.com"
+  },
+  {
+     "user_id": "3387c5ca-df92-40db-a3ee-fe3e592d8ffd",
+     "first_name": "Eileen",
+     "last_name": "Stroman",
+     "email": "Arnaldo.Klocko@hotmail.com"
+  },
+  {
+     "user_id": "9d963b37-ebb4-442e-a7ce-2378ba633903",
+     "first_name": "Hortense",
+     "last_name": "Collins",
+     "email": "Lexus_Wisozk2@gmail.com"
+  },
+  {
+     "user_id": "f1762897-9a80-4769-a5eb-043b9a826a7e",
+     "first_name": "Delta",
+     "last_name": "Hessel",
+     "email": "Rex_OHara@yahoo.com"
+  },
+  {
+     "user_id": "56d7000d-b855-49a3-adb7-9cf0a5d5013a",
+     "first_name": "Delpha",
+     "last_name": "Balistreri",
+     "email": "Roel84@hotmail.com"
+  },
+  {
+     "user_id": "f2a11bbf-5664-4afb-af44-9d56ba1b0b33",
+     "first_name": "Grace",
+     "last_name": "Lang",
+     "email": "Estell_Schmeler@gmail.com"
+  },
+  {
+     "user_id": "c1968ba5-2983-4f2c-945e-d848688b5939",
+     "first_name": "Helmer",
+     "last_name": "Hintz",
+     "email": "Fredy.Langosh16@hotmail.com"
+  },
+  {
+     "user_id": "9927e2cb-606f-48c0-9a8c-99219fc18a6c",
+     "first_name": "Ilene",
+     "last_name": "Altenwerth",
+     "email": "Ilene96@hotmail.com"
+  },
+  {
+     "user_id": "7a563701-2a69-4ce2-a4eb-9a7af4ca1dc8",
+     "first_name": "Rogelio",
+     "last_name": "Rodriguez",
+     "email": "Akeem.Ullrich@gmail.com"
+  },
+  {
+     "user_id": "4d71b794-2061-4564-b272-fab4b955e436",
+     "first_name": "Josiane",
+     "last_name": "Bogisich",
+     "email": "Hannah37@yahoo.com"
+  },
+  {
+     "user_id": "d14bfa72-19e9-4e07-b74b-b96e0857c3ca",
+     "first_name": "Jarrell",
+     "last_name": "Pfeffer",
+     "email": "Juliana_Thiel@gmail.com"
+  },
+  {
+     "user_id": "cab09542-7d14-41c7-918c-5e8c5b333643",
+     "first_name": "Jaqueline",
+     "last_name": "Kilback",
+     "email": "Gerald49@gmail.com"
+  },
+  {
+     "user_id": "7f518258-faf5-49d2-ac7c-dfbc2530906d",
+     "first_name": "Jedediah",
+     "last_name": "Mertz",
+     "email": "Bobbie.Ratke26@gmail.com"
+  },
+  {
+     "user_id": "41611c0c-ccb8-472c-8f05-f4cae768a603",
+     "first_name": "Georgianna",
+     "last_name": "Halvorson",
+     "email": "Freddy47@yahoo.com"
+  },
+  {
+     "user_id": "3e1a288d-633a-40ed-a75b-2ccd1c85d12c",
+     "first_name": "Darren",
+     "last_name": "Collins",
+     "email": "Halle_Pfannerstill@gmail.com"
+  },
+  {
+     "user_id": "d08456f8-37ab-44e2-b84e-b61a9b99f06a",
+     "first_name": "Frederick",
+     "last_name": "Gutkowski",
+     "email": "Hortense_Effertz@hotmail.com"
+  },
+  {
+     "user_id": "7d165179-7f06-4606-b363-1a9c9258c1e0",
+     "first_name": "Uriah",
+     "last_name": "Barrows",
+     "email": "Herminia_Cole8@hotmail.com"
+  },
+  {
+     "user_id": "c6e0cf36-2dfa-4fab-9c00-3ca62d364508",
+     "first_name": "Hiram",
+     "last_name": "Hayes",
+     "email": "Palma3@hotmail.com"
+  },
+  {
+     "user_id": "2e9a9467-b952-48c5-9298-558c85abe82a",
+     "first_name": "Jane",
+     "last_name": "Bayer",
+     "email": "Vena.Romaguera@hotmail.com"
+  },
+  {
+     "user_id": "ba4f2bdf-c06d-49d0-b9de-edee6f63a9e5",
+     "first_name": "Mack",
+     "last_name": "Weber",
+     "email": "Clovis.Prohaska59@gmail.com"
+  },
+  {
+     "user_id": "4eb72327-3678-474a-9fdd-0ed371f6f593",
+     "first_name": "Everett",
+     "last_name": "Johnson",
+     "email": "Assunta.Gleason@yahoo.com"
+  },
+  {
+     "user_id": "bd7f6c3f-02e9-4854-9dcf-0e1675c3d9ae",
+     "first_name": "John",
+     "last_name": "Boyer",
+     "email": "Eliza_Hansen@hotmail.com"
+  },
+  {
+     "user_id": "0bcfbd68-0bab-4252-8497-43147241f719",
+     "first_name": "Jayson",
+     "last_name": "Smith",
+     "email": "Nora_Bogan85@gmail.com"
+  },
+  {
+     "user_id": "adca5734-c61d-485e-b20b-b09c4c5040d5",
+     "first_name": "Mireille",
+     "last_name": "Monahan",
+     "email": "Erin_Leffler@hotmail.com"
+  },
+  {
+     "user_id": "1b00e7af-60db-4648-8631-ee0552fc17b9",
+     "first_name": "Fred",
+     "last_name": "Russel",
+     "email": "Anais_Rau@yahoo.com"
+  },
+  {
+     "user_id": "308cbb93-0fc5-4155-8195-38404f8f64ce",
+     "first_name": "John",
+     "last_name": "Cummings",
+     "email": "Leanne_Prohaska@hotmail.com"
+  },
+  {
+     "user_id": "25b753f3-9884-415a-a99d-9d5f246a359c",
+     "first_name": "Alan",
+     "last_name": "Smith",
+     "email": "Mckayla_Walter71@hotmail.com"
+  },
+  {
+     "user_id": "1d2bbaa2-eb96-4412-883e-616f6a891acf",
+     "first_name": "Derek",
+     "last_name": "Hegmann",
+     "email": "Allie84@gmail.com"
+  }
+]

--- a/app/api/user.js
+++ b/app/api/user.js
@@ -15,7 +15,10 @@ module.exports = {
       users = data
     }
 
-    res.json(users)
+    res.json({
+      count: users.length,
+      results: users,
+    })
   },
   introspect: (req, res) => {
     const uuid = req.query.user_id

--- a/app/api/user.js
+++ b/app/api/user.js
@@ -1,0 +1,31 @@
+const data = require('./user-list')
+
+function findUserByProp (prop, value) {
+  return (user) => user[ prop ] === value
+}
+
+module.exports = {
+  search: (req, res) => {
+    const text = req.query.autocomplete
+    let users
+
+    if (text) {
+      users = data.filter(({ first_name: fname, last_name: lname }) => (fname.includes(text) || lname.includes(text)))
+    } else {
+      users = data
+    }
+
+    res.json(users)
+  },
+  introspect: (req, res) => {
+    const uuid = req.query.user_id
+    const email = req.query.email
+    const user = data.find(findUserByProp((uuid ? 'user_id' : 'email'), (uuid || email)))
+
+    if (user) {
+      res.json(user)
+    } else {
+      res.status(404).end()
+    }
+  },
+}

--- a/app/api/user.js
+++ b/app/api/user.js
@@ -23,7 +23,8 @@ module.exports = {
   introspect: (req, res) => {
     const uuid = req.query.user_id
     const email = req.query.email
-    const user = data.find(findUserByProp((uuid ? 'user_id' : 'email'), (uuid || email)))
+    const args = (uuid ? ['user_id', uuid] : ['email', email])
+    const user = data.find(findUserByProp(...args))
 
     if (user) {
       res.json(user)

--- a/app/index.js
+++ b/app/index.js
@@ -9,6 +9,7 @@ const oAuthIntrospect = require('./oauth/introspect')
 const oAuthGetUserDetails = require('./oauth/user')
 const parseFormData = require('./form-data/parse')
 const ping = require('./healthcheck/ping')
+const userApi = require('./api/user')
 const catchAllErrors = require('./errors/catch-all')
 
 const app = express()
@@ -19,6 +20,8 @@ app.post('/o/token', parseFormData(), oAuthToken())
 app.post('/o/introspect', oAuthIntrospect(scope, username))
 app.get('/api/v1/user/me', oAuthGetUserDetails(token, validateToken === 'true'))
 app.get('/healthcheck', ping)
+app.get('/api/v1/user/search/', userApi.search)
+app.get('/api/v1/user/introspect/', userApi.introspect)
 
 app.use(catchAllErrors())
 

--- a/app/oauth/user.js
+++ b/app/oauth/user.js
@@ -33,7 +33,7 @@ const user = (configToken, validateToken) => {
 
     const response = {
       'email': 'vyvyan.holland@email.com',
-      'user_id': 123,
+      'user_id': '20a0353f-a7d1-4851-9af8-1bcaff152b60',
       'first_name': 'Vyvyan',
       'last_name': 'Holland',
       'related_emails': [],

--- a/tests/unit/api/user.test.js
+++ b/tests/unit/api/user.test.js
@@ -1,0 +1,95 @@
+const controller = require('../../../app/api/user')
+const users = require('../../../app/api/user-list.json')
+
+describe('User API', () => {
+  beforeEach(() => {
+    const end = jest.fn()
+
+    this.requestMock = { query: {} }
+    this.responseMock = {
+      json: jest.fn(),
+      status: jest.fn(() => ({ end })),
+      end,
+    }
+  })
+
+  describe('#search', () => {
+    describe('Without any query text', () => {
+      it('Returns all the results', () => {
+        controller.search(this.requestMock, this.responseMock)
+
+        expect(this.responseMock.json).toHaveBeenCalledWith({
+          count: users.length,
+          results: users,
+        })
+      })
+    })
+
+    describe('With query text', () => {
+      describe('When the query matches', () => {
+        it('Returns the correct results', () => {
+          const text = 'John'
+          const list = users.filter(({ first_name: fname, last_name: lname }) => (fname.includes(text) || lname.includes(text)))
+
+          this.requestMock.query.autocomplete = text
+          controller.search(this.requestMock, this.responseMock)
+
+          expect(this.responseMock.json).toHaveBeenCalledWith({
+            count: list.length,
+            results: list,
+          })
+        })
+      })
+
+      describe('When the query does not match', () => {
+        it('Returns the correct results', () => {
+          const text = 'abc-123'
+          const list = []
+
+          this.requestMock.query.autocomplete = text
+          controller.search(this.requestMock, this.responseMock)
+
+          expect(this.responseMock.json).toHaveBeenCalledWith({
+            count: list.length,
+            results: list,
+          })
+        })
+      })
+    })
+  })
+
+  describe('#introspect', () => {
+    describe('When the user cannot be found', () => {
+      it('Returns 404', () => {
+        controller.introspect(this.requestMock, this.responseMock)
+
+        expect(this.responseMock.status).toHaveBeenCalledWith(404)
+        expect(this.responseMock.end).toHaveBeenCalled()
+      })
+    })
+
+    describe('When the user can be found', () => {
+      describe('When the user id matches', () => {
+        it('Returns the user', () => {
+          const user = users[ 1 ]
+
+          this.requestMock.query.user_id = user.user_id
+          controller.introspect(this.requestMock, this.responseMock)
+
+          expect(this.responseMock.json).toHaveBeenCalledWith(user)
+        })
+      })
+
+      describe('When the user email matches', () => {
+        it('Returns the user', () => {
+          const user = users[ 2 ]
+
+          this.requestMock.query.email = user.email
+          controller.introspect(this.requestMock, this.responseMock)
+
+          expect(this.responseMock.json).toHaveBeenCalledWith(user)
+        })
+      })
+    })
+  })
+})

--- a/tests/unit/oauth/user.test.js
+++ b/tests/unit/oauth/user.test.js
@@ -21,7 +21,7 @@ describe('#user', () => {
       last_name: 'Holland',
       permitted_applications: [{ key: 'datahub-crm' }, { key: 'datahub-mi' }, { key: 'market-access' }],
       related_emails: [],
-      user_id: 123,
+      user_id: '20a0353f-a7d1-4851-9af8-1bcaff152b60',
     }
   })
 


### PR DESCRIPTION
To match changes that have happened in the real SSO this adds two new APIs

1) `/api/v1/user/search/` which takes an `autocomplete` query param for the search term
2) `/api/v1/user/introspect/` which takes either `user_id` or `email` query param to find a user

This PR adds a list of mock users which get returned.

Also the `user_id` for the mock oauth user has been changed to be a valid UUID so that is passes validation checks