### PR TITLE
Add LEP auth user response without permission to market access and da…

### DIFF
--- a/app/oauth/user.js
+++ b/app/oauth/user.js
@@ -31,6 +31,22 @@ const user = (configToken, validateToken) => {
       }
     }
 
+    if (header.includes('lepStaffToken')) {
+      const response = {
+        'email': 'LEP.STAFF@email.com',
+        'contact_email': 'LEP.STAFF@contact-email.com',
+        'user_id': '20a0353f-a7d1-4851-9af8-1bcaff152b61',
+        'first_name': 'LEP',
+        'last_name': 'STAFF',
+        'related_emails': [],
+        'groups': [],
+        'permitted_applications': [],
+        'access_profiles': [],
+      }
+
+      return res.status(200).send(response)
+    }
+
     const response = {
       'email': 'vyvyan.holland@email.com',
       'contact_email': 'vyvyan.holland@contact-email.com',

--- a/tests/unit/oauth/user.test.js
+++ b/tests/unit/oauth/user.test.js
@@ -128,4 +128,33 @@ describe('#user', () => {
       expect(this.responseMock.send).toHaveBeenCalledWith(this.validUserResponse)
     })
   })
+
+  describe('with a LEP valid token', () => {
+    beforeEach(() => {
+      this.validLepUserResponse = {
+        access_profiles: [],
+        email: 'LEP.STAFF@email.com',
+        contact_email: 'LEP.STAFF@contact-email.com',
+        first_name: 'LEP',
+        groups: [],
+        last_name: 'STAFF',
+        permitted_applications: [],
+        related_emails: [],
+        user_id: '20a0353f-a7d1-4851-9af8-1bcaff152b61',
+      }
+      this.mockToken = 'lepStaffToken'
+
+      this.requestMock.headers.authorization = `Bearer ${this.mockToken}`
+      this.middleware = user(this.mockToken)(this.requestMock, this.responseMock, this.nextMock)
+    })
+
+    test('next should not be called', () => {
+      expect(this.nextMock).not.toHaveBeenCalled()
+    })
+
+    test('a 200 with a valid response shoulld be returned', () => {
+      expect(this.responseMock.status).toHaveBeenCalledWith(200)
+      expect(this.responseMock.send).toHaveBeenCalledWith(this.validLepUserResponse)
+    })
+  })
 })


### PR DESCRIPTION
Ensuring we have a different response returned if auth user has lep on it.

In the real world LEP users shouldn't have access to market access and dashboard