### PR TITLE
Feat: Add email override options

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,17 @@ A simple app for testing the cogs involved with SSO integration. Simply replies 
 Thanks for the thoughts and influence from [r4vi/fakesso](https://github.com/r4vi/fakesso)
 
 ## Environment variables
-| Name                    |  Description                                    |
-|:------------------------|:------------------------------------------------|
-| MOCK_SSO_PORT           | The applications port, defaults to `8080`       |
-| MOCK_SSO_USERNAME       | The SSO username to create an SSO token for.    |
-| MOCK_SSO_EMAIL_USER_ID  | The required SSO email user id.                 |
-| MOCK_SSO_SCOPE          | The required introspect scope                   |
-| MOCK_SSO_CODE           | The code passed to the source application       |
-| MOCK_SSO_TOKEN          | The required user token for optional validation |
-| MOCK_SSO_VALIDATE_TOKEN | Whether to validate the token for the user      |
+| Name                            |  Description                                        |
+|:--------------------------------|:----------------------------------------------------|
+| MOCK_SSO_PORT                   | The applications port, defaults to `8080`           |
+| MOCK_SSO_USERNAME               | The SSO username to create an SSO token for.        |
+| MOCK_SSO_USER_EMAIL             | An optional value for the SSO user email.           |
+| MOCK_SSO_USER_CONTACT_EMAIL     | An optional value for the SSO user contact email.   |
+| MOCK_SSO_EMAIL_USER_ID          | The required SSO email user id.                     |
+| MOCK_SSO_SCOPE                  | The required introspect scope                       |
+| MOCK_SSO_CODE                   | The code passed to the source application           |
+| MOCK_SSO_TOKEN                  | The required user token for optional validation     |
+| MOCK_SSO_VALIDATE_TOKEN         | Whether to validate the token for the user          |
 
 ## Development
 ### Setup

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -2,6 +2,8 @@ const config = {
   port: process.env.MOCK_SSO_PORT || 8080,
   scope: process.env.MOCK_SSO_SCOPE,
   username: process.env.MOCK_SSO_USERNAME,
+  userEmail: process.env.MOCK_SSO_USER_EMAIL,
+  userContactEmail: process.env.MOCK_SSO_USER_CONTACT_EMAIL,
   emailUserId: process.env.MOCK_SSO_EMAIL_USER_ID,
   token: process.env.MOCK_SSO_TOKEN,
   validateToken: process.env.MOCK_SSO_VALIDATE_TOKEN,

--- a/app/index.js
+++ b/app/index.js
@@ -1,7 +1,7 @@
 const express = require('express')
 const morgan = require('morgan')
 
-const { port, scope, username, emailUserId, token, validateToken, code } = require('./config')
+const { port, scope, username, userEmail, emailUserId, token, validateToken, code, userContactEmail } = require('./config')
 
 const oAuthAuthorize = require('./oauth/authorize')
 const oAuthToken = require('./oauth/token')
@@ -18,7 +18,7 @@ app.use(morgan('dev'))
 app.get('/o/authorize', oAuthAuthorize(code))
 app.post('/o/token', parseFormData(), oAuthToken())
 app.post('/o/introspect', oAuthIntrospect(scope, username, emailUserId))
-app.get('/api/v1/user/me', oAuthGetUserDetails(token, validateToken === 'true'))
+app.get('/api/v1/user/me', oAuthGetUserDetails(token, userEmail, userContactEmail, validateToken === 'true'))
 app.get('/healthcheck', ping)
 app.get('/api/v1/user/search/', userApi.search)
 app.get('/api/v1/user/introspect/', userApi.introspect)

--- a/app/oauth/user.js
+++ b/app/oauth/user.js
@@ -5,7 +5,7 @@ function invalidRequest (res, error) {
   return res.status(400).json({ error: 'invalid_request' })
 }
 
-const user = (configToken, validateToken) => {
+const user = (configToken, userEmail, userContactEmail, validateToken) => {
   return function (req, res, next) {
     if (!configToken) {
       return next(new Error('Please provide configToken'))
@@ -49,8 +49,8 @@ const user = (configToken, validateToken) => {
     }
 
     const response = {
-      'email': 'vyvyan.holland@email.com',
-      'contact_email': 'vyvyan.holland@contact-email.com',
+      'email': userEmail || 'vyvyan.holland@email.com',
+      'contact_email': userContactEmail || 'vyvyan.holland@contact-email.com',
       'email_user_id': 'vyvyan.holland-20a0353f@id.mock-sso',
       'user_id': '20a0353f-a7d1-4851-9af8-1bcaff152b60',
       'first_name': 'Vyvyan',

--- a/tests/unit/oauth/user.test.js
+++ b/tests/unit/oauth/user.test.js
@@ -85,7 +85,7 @@ describe('#user', () => {
 
     describe('With validateToken set to true', () => {
       beforeEach(() => {
-        this.middleware = user(this.mockToken, true)(this.requestMock, this.responseMock, this.nextMock)
+        this.middleware = user(this.mockToken, undefined, undefined, true)(this.requestMock, this.responseMock, this.nextMock)
       })
 
       test('next should not be called', () => {
@@ -157,6 +157,50 @@ describe('#user', () => {
     test('a 200 with a valid response shoulld be returned', () => {
       expect(this.responseMock.status).toHaveBeenCalledWith(200)
       expect(this.responseMock.send).toHaveBeenCalledWith(this.validLepUserResponse)
+    })
+  })
+  describe('with a user email', () => {
+    beforeEach(() => {
+      this.requestMock.headers.authorization = 'Bearer ' + this.mockToken
+      this.middleware = user(this.mockToken, 'useremail@digital.trade.gov.uk')(
+        this.requestMock,
+        this.responseMock,
+        this.nextMock
+      )
+    })
+
+    test('next should not be called', () => {
+      expect(this.nextMock).not.toHaveBeenCalled()
+    })
+
+    test('user email should be overriden', () => {
+      expect(this.responseMock.status).toHaveBeenCalledWith(200)
+      expect(this.responseMock.send).toHaveBeenCalledWith({
+        ...this.validUserResponse,
+        email: 'useremail@digital.trade.gov.uk',
+      })
+    })
+  })
+  describe('with a user contact email', () => {
+    beforeEach(() => {
+      this.requestMock.headers.authorization = 'Bearer ' + this.mockToken
+      this.middleware = user(
+        this.mockToken,
+        undefined,
+        'usercontactemail@digital.trade.gov.uk',
+      )(this.requestMock, this.responseMock, this.nextMock)
+    })
+
+    test('next should not be called', () => {
+      expect(this.nextMock).not.toHaveBeenCalled()
+    })
+
+    test('user contact email should be overriden', () => {
+      expect(this.responseMock.status).toHaveBeenCalledWith(200)
+      expect(this.responseMock.send).toHaveBeenCalledWith({
+        ...this.validUserResponse,
+        contact_email: 'usercontactemail@digital.trade.gov.uk',
+      })
     })
   })
 })


### PR DESCRIPTION
This change will allow users to override the default users email and contact email. This is useful for when we want to end to end test a user with a slightly different profile. If you don't choose to use the new env variables then the default values will be used instead. 